### PR TITLE
Removing parser attribute, updating rules for eslint v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # eslint-config-opentable-es5
 
-This package provides a standard Opentable .eslintrc as an extensible shared config. It's roughly built around airbnbs style guide
+This package provides a standard Opentable .eslintrc as an extensible shared config. It's roughly built around airbnbs style guide.
+
+Requires eslint v2.
 
 ## Usage
 
-1. `npm install --save-dev eslint-config-opentable-es5 `
-2. add `"extends": "eslint-config-opentable-es5"` to your .eslintrc
+```shell
+npm install --save-dev eslint-config-opentable-es5
+```
 
+add `"extends": "eslint-config-opentable-es5"` to your .eslintrc
+
+If using babel:
+
+add `"parser": "babel-eslint"` to your .eslintrc
 
 ## Changelog
 

--- a/base/index.js
+++ b/base/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  "parser": "babel-eslint",
   "env": {
     "browser": true,
     "node": true
@@ -161,11 +160,10 @@ module.exports = {
       "before": false,
       "after": true
     }],
-    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "keyword-spacing": 2,            // http://eslint.org/docs/rules/keyword-spacing
     "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
-    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
     "spaced-comment": 2              // http://eslint.org/docs/rules/spaced-comment
   }
 };


### PR DESCRIPTION
When extending a rule file, the parser cannot be overridden (I attempted to set it to the default `espree` in a project and it still attempted to use `babel-eslint`). This doesn't make sense for projects in an ES6 environment (e.g. Node v6).

Also, `space-return-throw-case` and `space-after-keywords` were merged into `keyword-spacing` as of eslint 2.0, so I updated those rules as well.

This change requires changes in the consumer (parser=babel-eslint AND eslint@v2), so this PR is a MAJOR change (Semver pre 1.0.0 states this can be a MINOR version bump, `0.2.0`).