### PR TITLE
Adding object-shorthand and prefer-const rules

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -41,6 +41,8 @@ module.exports = {
  * ES6
  */
     "no-var": 2,                     // http://eslint.org/docs/rules/no-var
+    "object-shorthand": 2,           // http://eslint.org/docs/rules/object-shorthand
+    "prefer-const": 2,               // http://eslint.org/docs/rules/prefer-const
 
 /**
  * Variables


### PR DESCRIPTION
# Breaking Change

SEMVER MAJOR, however as we're pre 1.0, we should do a MINOR:

```bash
npm version minor
```

## object-shorthand

http://eslint.org/docs/rules/object-shorthand

* Property assignment, if having same name as variable, must omit the colon
* Object methods should omit the `function`

```es6
// properties
var x = 1, y = 2, z = 3;
var foo = {x, y, z};

// methods
var foo = {
    a() {},
    b() {}
};
```

## prefer-const

http://eslint.org/docs/rules/prefer-const

* If a variable is not reassigned it should be `const` instead of a `let`